### PR TITLE
Use matrix.to instead of hardcoding element:\\ when linking to the Matrix room

### DIFF
--- a/docs/start.html
+++ b/docs/start.html
@@ -18,7 +18,7 @@ you want to do. For full details and examples, have a look at the <a href="manua
 <p>If you are having trouble, or if something is not working, here are some great places to ask for help:</p>
 <ul>
 <li>The <a href="https://github.com/markqvist/Reticulum/discussions">discussion forum</a> on GitHub</li>
-<li>The <a href="element://room/!TRaVWNnQhAbvuiSnEK%3Amatrix.org?via=matrix.org">Reticulum Matrix Channel</a> at <code>#reticulum:matrix.org</code></li>
+<li>The <a href="https://matrix.to/#/#reticulum:matrix.org">Reticulum Matrix Channel</a> at <code>#reticulum:matrix.org</code></li>
 <li>The <a href="https://reddit.com/r/reticulum">Reticulum subreddit</a></li>
 </ul>
 <h2>Installation</h2>

--- a/docs/start_de.html
+++ b/docs/start_de.html
@@ -18,7 +18,7 @@ Sie durchführen möchten. Ausführliche Informationen und Beispiele finden Sie 
 <p>Wenn Sie Probleme haben oder etwas nicht funktioniert, finden Sie hier einige gute Stellen, an denen Sie um Hilfe bitten können:</p>
 <ul>
 <li>Das <a href="https://github.com/markqvist/Reticulum/discussions">Diskussionsforum</a> auf GitHub</li>
-<li>Der <a href="element://room/!TRaVWNnQhAbvuiSnEK%3Amatrix.org?via=matrix.org">Reticulum-Matrixkanal</a> bei <code>#reticulum:matrix.org</code></li>
+<li>Der <a href="https://matrix.to/#/#reticulum:matrix.org">Reticulum-Matrixkanal</a> bei <code>#reticulum:matrix.org</code></li>
 <li>Der <a href="https://reddit.com/r/reticulum">Reticulum-Subreddit</a></li>
 </ul>
 <h2>Installation</h2>

--- a/docs/start_jp.html
+++ b/docs/start_jp.html
@@ -17,7 +17,7 @@
 <p>問題が発生したり、何かがうまく動作しない場合は、助けを求めるための優れた場所がいくつかあります：</p>
 <ul>
 <li>GitHubの<a href="https://github.com/markqvist/Reticulum/discussions">discussion forum</a></li>
-<li><a href="element://room/!TRaVWNnQhAbvuiSnEK%3Amatrix.org?via=matrix.org">Reticulum Matrix Channel</a>の<code>#reticulum:matrix.org</code></li>
+<li><a href="https://matrix.to/#/#reticulum:matrix.org">Reticulum Matrix Channel</a>の<code>#reticulum:matrix.org</code></li>
 <li><a href="https://reddit.com/r/reticulum">Reticulum subreddit</a></li>
 </ul>
 <h2>インストール</h2>

--- a/docs/start_pl.html
+++ b/docs/start_pl.html
@@ -18,7 +18,7 @@ co chcesz zrobić. Aby uzyskać pełne szczegóły i przykłady, sprawdź rodzia
 <p>Jeśli masz problemy lub coś nie działa, oto kilka świetnych miejsc, w których możesz poprosić o pomoc:</p>
 <ul>
 <li><a href="https://github.com/markqvist/Reticulum/discussions">Forum dyskusyjne</a> na GitHubie</li>
-<li>Kanał <a href="element://room/!TRaVWNnQhAbvuiSnEK%3Amatrix.org?via=matrix.org">Matrix Reticulum</a> pod <code>#reticulum:matrix.org</code></li>
+<li>Kanał <a href="https://matrix.to/#/#reticulum:matrix.org">Matrix Reticulum</a> pod <code>#reticulum:matrix.org</code></li>
 <li><a href="https://reddit.com/r/reticulum">Subreddit Reticulum</a></li>
 </ul>
 <h2>Instalacja</h2>

--- a/docs/start_pt-br.html
+++ b/docs/start_pt-br.html
@@ -18,7 +18,7 @@ Utilize o Reticulum se estiver confortável em relação a isso e entenda suas i
 <p>Se você estiver com problemas ou se algo não estiver funcionando, aqui estão alguns ótimos lugares para pedir ajuda:</p>
 <ul>
 <li>O <a href="https://github.com/markqvist/Reticulum/discussions">fórum de discussão</a> no GitHub</li>
-<li>O canal da <a href="element://room/!TRaVWNnQhAbvuiSnEK%3Amatrix.org?via=matrix.org">Matrix do Retículum</a> em <code>#reticulum:matrix.org</code></li>
+<li>O canal da <a href="https://matrix.to/#/#reticulum:matrix.org">Matrix do Retículum</a> em <code>#reticulum:matrix.org</code></li>
 <li>O <a href="https://reddit.com/r/reticulum">subreddit Reticulum</a></li>
 </ul>
 <h2>Instalação</h2>

--- a/docs/start_tr.html
+++ b/docs/start_tr.html
@@ -17,7 +17,7 @@
 <p>Eğer sorun yaşarsanız veya bir şey çalışmıyorsa, yardım istemek için harika yerler şunlar:</p>
 <ul>
 <li><a href="https://github.com/markqvist/Reticulum/discussions">GitHub'daki tartışma forumu</a></li>
-<li><code>#reticulum:matrix.org</code> üzerinden <a href="element://room/!TRaVWNnQhAbvuiSnEK%3Amatrix.org?via=matrix.org">Reticulum Matrix Kanalı</a></li>
+<li><code>#reticulum:matrix.org</code> üzerinden <a href="https://matrix.to/#/#reticulum:matrix.org">Reticulum Matrix Kanalı</a></li>
 <li><a href="https://reddit.com/r/reticulum">Reticulum subreddit'i</a></li>
 </ul>
 <h2>Kurulum</h2>

--- a/docs/start_zh-cn.html
+++ b/docs/start_zh-cn.html
@@ -17,7 +17,7 @@
 <p>如果你遇到了问题，又或是有些东西不工作，以下是一些寻求帮助的好地方：</p>
 <ul>
 <li><a href="https://github.com/markqvist/Reticulum/discussions">Reticulum Github 讨论区</a></li>
-<li><a href="element://room/!TRaVWNnQhAbvuiSnEK%3Amatrix.org?via=matrix.org">Reticulum Matrix 群组</a>（<code>#reticulum:matrix.org</code>）</li>
+<li><a href="https://matrix.to/#/#reticulum:matrix.org">Reticulum Matrix 群组</a>（<code>#reticulum:matrix.org</code>）</li>
 <li><a href="https://reddit.com/r/reticulum">Reticulum Reddit 讨论版</a></li>
 </ul>
 <h2>安装</h2>

--- a/source/start.md
+++ b/source/start.md
@@ -10,7 +10,7 @@ you want to do. For full details and examples, have a look at the [Getting Start
 If you are having trouble, or if something is not working, here are some great places to ask for help:
 
 - The [discussion forum](https://github.com/markqvist/Reticulum/discussions) on GitHub
-- The [Reticulum Matrix Channel](element://room/!TRaVWNnQhAbvuiSnEK%3Amatrix.org?via=matrix.org) at `#reticulum:matrix.org`
+- The [Reticulum Matrix Channel](https://matrix.to/#/#reticulum:matrix.org) at `#reticulum:matrix.org`
 - The [Reticulum subreddit](https://reddit.com/r/reticulum)
 
 ## Installation

--- a/source/start_de.md
+++ b/source/start_de.md
@@ -9,7 +9,7 @@ Sie durchführen möchten. Ausführliche Informationen und Beispiele finden Sie 
 Wenn Sie Probleme haben oder etwas nicht funktioniert, finden Sie hier einige gute Stellen, an denen Sie um Hilfe bitten können:
 
 - Das [Diskussionsforum](https://github.com/markqvist/Reticulum/discussions) auf GitHub
-- Der [Reticulum-Matrixkanal](element://room/!TRaVWNnQhAbvuiSnEK%3Amatrix.org?via=matrix.org) bei `#reticulum:matrix.org`
+- Der [Reticulum-Matrixkanal](https://matrix.to/#/#reticulum:matrix.org) bei `#reticulum:matrix.org`
 - Der [Reticulum-Subreddit](https://reddit.com/r/reticulum)
 
 ## Installation

--- a/source/start_jp.md
+++ b/source/start_jp.md
@@ -8,7 +8,7 @@ Reticulum Network Stackを始める最良の方法は、行いたいことによ
 問題が発生したり、何かがうまく動作しない場合は、助けを求めるための優れた場所がいくつかあります：
 
 - GitHubの[discussion forum](https://github.com/markqvist/Reticulum/discussions)
-- [Reticulum Matrix Channel](element://room/!TRaVWNnQhAbvuiSnEK%3Amatrix.org?via=matrix.org)の`#reticulum:matrix.org`
+- [Reticulum Matrix Channel](https://matrix.to/#/#reticulum:matrix.org)の`#reticulum:matrix.org`
 - [Reticulum subreddit](https://reddit.com/r/reticulum)
 
 ## インストール

--- a/source/start_pl.md
+++ b/source/start_pl.md
@@ -10,7 +10,7 @@ co chcesz zrobić. Aby uzyskać pełne szczegóły i przykłady, sprawdź rodzia
 Jeśli masz problemy lub coś nie działa, oto kilka świetnych miejsc, w których możesz poprosić o pomoc:
 
 - [Forum dyskusyjne](https://github.com/markqvist/Reticulum/discussions) na GitHubie
-- Kanał [Matrix Reticulum](element://room/!TRaVWNnQhAbvuiSnEK%3Amatrix.org?via=matrix.org) pod `#reticulum:matrix.org`
+- Kanał [Matrix Reticulum](https://matrix.to/#/#reticulum:matrix.org) pod `#reticulum:matrix.org`
 - [Subreddit Reticulum](https://reddit.com/r/reticulum)
 
 ## Instalacja

--- a/source/start_pt-br.md
+++ b/source/start_pt-br.md
@@ -12,7 +12,7 @@ Utilize o Reticulum se estiver confortável em relação a isso e entenda suas i
 Se você estiver com problemas ou se algo não estiver funcionando, aqui estão alguns ótimos lugares para pedir ajuda:
 
 - O [fórum de discussão](https://github.com/markqvist/Reticulum/discussions) no GitHub
-- O canal da [Matrix do Retículum](element://room/!TRaVWNnQhAbvuiSnEK%3Amatrix.org?via=matrix.org) em `#reticulum:matrix.org`
+- O canal da [Matrix do Retículum](https://matrix.to/#/#reticulum:matrix.org) em `#reticulum:matrix.org`
 - O [subreddit Reticulum](https://reddit.com/r/reticulum)
 
 ## Instalação

--- a/source/start_tr.md
+++ b/source/start_tr.md
@@ -8,7 +8,7 @@ Reticulum Ağı ile başlamanın en iyi yolu, ne yapmak istediğinize bağlıdı
 Eğer sorun yaşarsanız veya bir şey çalışmıyorsa, yardım istemek için harika yerler şunlar:
 
 - [GitHub'daki tartışma forumu](https://github.com/markqvist/Reticulum/discussions)
-- `#reticulum:matrix.org` üzerinden [Reticulum Matrix Kanalı](element://room/!TRaVWNnQhAbvuiSnEK%3Amatrix.org?via=matrix.org)
+- `#reticulum:matrix.org` üzerinden [Reticulum Matrix Kanalı](https://matrix.to/#/#reticulum:matrix.org)
 - [Reticulum subreddit'i](https://reddit.com/r/reticulum)
 
 ## Kurulum

--- a/source/start_zh-cn.md
+++ b/source/start_zh-cn.md
@@ -9,7 +9,7 @@
 如果你遇到了问题，又或是有些东西不工作，以下是一些寻求帮助的好地方：
 
 - [Reticulum Github 讨论区](https://github.com/markqvist/Reticulum/discussions)
-- [Reticulum Matrix 群组](element://room/!TRaVWNnQhAbvuiSnEK%3Amatrix.org?via=matrix.org)（`#reticulum:matrix.org`）
+- [Reticulum Matrix 群组](https://matrix.to/#/#reticulum:matrix.org)（`#reticulum:matrix.org`）
 - [Reticulum Reddit 讨论版](https://reddit.com/r/reticulum)
 
 ## 安装


### PR DESCRIPTION
matrix.to is the canonical way of linking to a matrix room across clients or messages. `element:\\` only works if one has element installed and won't work with other clients (fluffychat, fractal, cinny, etc).