### PR TITLE
Improved Dutch translations

### DIFF
--- a/source/crypto_nl.md
+++ b/source/crypto_nl.md
@@ -23,4 +23,4 @@ Als u de interne pure Python-primitieven wilt gebruiken, is het **zeer aan te ra
 
 Reticulum is relatief jonge software en moet als zodanig worden beschouwd. Hoewel het is gebouwd met de best practices op het gebied van cryptografie in het achterhoofd, is er geen externe beveiligingsaudit uitgevoerd en kunnen er bugs in zitten die de privacy of de beveiliging schenden. Als u wilt helpen of een audit wilt sponsoren, neem dan contact met ons op.
 
-<p align="right"><a href="credits_nl.html">Volgend onderwerp: dankbetuigingen en credits</a></p>
+<p align="right"><a href="credits_nl.html">Volgend onderwerp: dankbetuigingen en referenties</a></p>

--- a/source/docs_nl.md
+++ b/source/docs_nl.md
@@ -1,5 +1,5 @@
 # Lees de handleiding
-YU kunt door de volledige documentatie voor Reticulum bladeren [op deze site](manual/index.html) of [op GitHub Pages](https://markqvist.github.io/Reticulum/manual/).
+U kunt door de volledige documentatie voor Reticulum bladeren [op deze site](manual/index.html) of [op GitHub Pages](https://markqvist.github.io/Reticulum/manual/).
 
 U kunt ook [de Reticulum-handleiding downloaden als PDF](manual/Reticulum%20Manual.pdf) of in [EPUB format](manual/Reticulum%20Manual.epub).
 

--- a/source/index_nl.md
+++ b/source/index_nl.md
@@ -19,7 +19,7 @@ Hoewel Reticulum hetzelfde probleem oplost als elke netwerkstack, namelijk gegev
 - Er is geen centrale controle over de adresruimte in Reticulum. Iedereen kan zoveel adressen toewijzen als hij nodig heeft, wanneer hij die nodig heeft..
 - Reticulum zorgt voor end-to-end connectiviteit. Nieuw gegenereerde adressen worden binnen enkele seconden tot enkele minuten wereldwijd bereikbaar.
 - Adressen zijn *zelf-soeverein* en *draagbaar*. Zodra een adres is aangemaakt, kan het fysiek naar een andere plek in het netwerk worden verplaatst en bereikbaar blijven.
-- Alle communicatie is standaard beveiligd met [sterke, moderne encryptie](crypto.html).
+- Alle communicatie is standaard beveiligd met [sterke, moderne encryptie](crypto_nl.html).
 - Alle encryptiesleutels zijn kortstondig en communicatie biedt standaard voorwaartse geheimhouding.
 - Het is niet mogelijk om ongecodeerde links tot stand te brengen in Reticulum-netwerken.
 - Het is niet mogelijk om ongecodeerde pakketten naar bestemmingen in het netwerk te verzenden.

--- a/source/start_nl.md
+++ b/source/start_nl.md
@@ -58,7 +58,7 @@ Op meer ongebruikelijke systemen, en in sommige zeldzame gevallen, is het missch
 
 Ongeacht hoe Reticulum is geïnstalleerd en gestart, het zal alleen externe afhankelijkheden laden als deze *nodig* en *beschikbaar* zijn. Als u bijvoorbeeld Reticulum wilt gebruiken op een systeem dat [pyserial](https://github.com/pyserial/pyserial) niet kan ondersteunen, is het perfect mogelijk om dit te doen met het `rnspure`-pakket, maar Reticulum zal dan niet in staat zijn om seriële interfaces te gebruiken. Alle andere beschikbare modules worden nog steeds geladen wanneer dat nodig is.
 
-**Let op!** Als u het `rnspure`-pakket gebruikt om Reticulum uit te voeren op systemen die [PyCA/cryptography](https://github.com/pyca/cryptography) niet ondersteunen, is het belangrijk dat u eerst het [Cryptographic Primitives](crypto.html) hoofdstuk van deze site leest en begrijpt.
+**Let op!** Als u het `rnspure`-pakket gebruikt om Reticulum uit te voeren op systemen die [PyCA/cryptography](https://github.com/pyca/cryptography) niet ondersteunen, is het belangrijk dat u eerst het [Cryptografische Primitieven](crypto_nl.html) hoofdstuk van deze site leest en begrijpt.
 
 ## Prestatie
 Reticulum streeft naar een *zeer* breed bruikbaar prestatiebereik, maar geeft prioriteit aan functionaliteit en prestaties boven mediums met een lage bandbreedte. Het doel is om een dynamisch prestatiebereik te bieden van 250 bits per seconde tot 1 gigabit per seconde op normale hardware.


### PR DESCRIPTION
Links on Dutch pages refer to their proper Dutch versions, improved few translations, removed typo