### PR TITLE
Change "Crypto" to "Cryptography" build.py menu translations

### DIFF
--- a/build.py
+++ b/build.py
@@ -46,7 +46,7 @@ menu_translations = {
         "HARDWARE": "Hardware",
         "TESTNET": "Testnet",
         "MANUAL": "Manual",
-        "CRYPTO": "Crypto",
+        "CRYPTO": "Cryptography",
         "CREDITS": "Credits",
         "SOURCE": "Source",
         "DONATE": "Donate",


### PR DESCRIPTION
I think the "Crypto" page needs to be renamed in the header to "Cryptography".
This will help avoid misinterpretations caused by the unfortunate re-appropriation of the word "crypto" by modern silicon-valley grifters.

As @faragher put it, the situation is "Lamentable, but not untrue."