### PR TITLE
docs: Add link to the Matrix Space

### DIFF
--- a/docs/start.html
+++ b/docs/start.html
@@ -18,7 +18,7 @@ you want to do. For full details and examples, have a look at the <a href="manua
 <p>If you are having trouble, or if something is not working, here are some great places to ask for help:</p>
 <ul>
 <li>The <a href="https://github.com/markqvist/Reticulum/discussions">discussion forum</a> on GitHub</li>
-<li>The <a href="https://matrix.to/#/#reticulum:matrix.org">Reticulum Matrix Channel</a> at <code>#reticulum:matrix.org</code></li>
+<li>The <a href="https://matrix.to/#/#reticulum:matrix.org">Reticulum Matrix Channel</a> at <code>#reticulum:matrix.org</code> and the <a href="https://matrix.to/#/#rns:matrix.org">Reticulum Matrix Space</a>.</li>
 <li>The <a href="https://reddit.com/r/reticulum">Reticulum subreddit</a></li>
 </ul>
 <h2>Installation</h2>

--- a/source/start.md
+++ b/source/start.md
@@ -10,7 +10,7 @@ you want to do. For full details and examples, have a look at the [Getting Start
 If you are having trouble, or if something is not working, here are some great places to ask for help:
 
 - The [discussion forum](https://github.com/markqvist/Reticulum/discussions) on GitHub
-- The [Reticulum Matrix Channel](https://matrix.to/#/#reticulum:matrix.org) at `#reticulum:matrix.org`
+- The [Reticulum Matrix Channel](https://matrix.to/#/#reticulum:matrix.org) at `#reticulum:matrix.org` and the [Reticulum Matrix Space](https://matrix.to/#/#rns:matrix.org).
 - The [Reticulum subreddit](https://reddit.com/r/reticulum)
 
 ## Installation


### PR DESCRIPTION
Add a mention of the RNS Matrix space to the website. I didn't touch the non-english sources as I think it would be best to leave it up to someone knowledgeable in each language, but if we want I can take a swing at some of them.